### PR TITLE
Add additional extensions for Photos

### DIFF
--- a/ImportPhotoFolders.applescript
+++ b/ImportPhotoFolders.applescript
@@ -64,7 +64,7 @@ on createFotoAlbum(albumName, parentFolder)
 end createFotoAlbum
 
 on getImageList(aFolder)
-	set extensionsList to {"jpg", "png", "tiff", "JPG", "jpeg", "gif", "JPEG", "PNG", "TIFF", "GIF", "MOV", "mov", "MP4", "mp4"}
+	set extensionsList to {"jpg", "png", "tiff", "JPG", "jpeg", "gif", "JPEG", "PNG", "TIFF", "GIF", "MOV", "mov", "MP4", "mp4", "MPG", "mpg", "BMP", "bmp", "TIF", "tif", "AVI", "avi", "PSD", "psd", "ai", "AI"}
 	tell application "Finder" to set theFiles to every file of aFolder whose name extension is in extensionsList
 
 	set imageList to {}


### PR DESCRIPTION
Photos supports a few more files (including importing AVI's now) - so expanding to ensure those files aren't missed.
